### PR TITLE
calendars/training: Add 2022 summer kickstart

### DIFF
--- a/calendars/training.yaml
+++ b/calendars/training.yaml
@@ -1,6 +1,8 @@
 name: Public events
 timezone: Europe/Helsinki
 
+
+# Newer events added to the top
 events:
   - &kickstart-2022-summer
     summary: Scientific Computing Kickstart (+HPC kickstart)
@@ -51,9 +53,9 @@ events:
     duration: {hours: 4}
     begin: 2022-06-07 12:00:00
   - <<: *kickstart-2022-summer
-    begin: 2022-06-08 12:00:00
-  - <<: *kickstart-2022-summer
     begin: 2022-06-09 12:00:00
+  - <<: *kickstart-2022-summer
+    begin: 2022-06-10 12:00:00
 
 
   - &swd4sc202204

--- a/calendars/training.yaml
+++ b/calendars/training.yaml
@@ -2,6 +2,60 @@ name: Public events
 timezone: Europe/Helsinki
 
 events:
+  - &kickstart-2022-summer
+    summary: Scientific Computing Kickstart (+HPC kickstart)
+    description:
+    location: https://twitch.tv/coderefinery
+    description: |
+      https://scicomp.aalto.fi/training/scip/summer-kickstart-2022/
+
+      Day 1:
+
+        This course is a general introduction to computational
+        researchers. The point is to serve as a guide to your career:
+        a map to the types of resources that are available and skills
+        you may need in your career, so that you can be prepared when
+        you need more in the future. There will also be topics related
+        to using these resources. Aalto University is used in some
+        examples, but all parts are designed to be useful no matter
+        where you are now.
+
+        This course is especially suitable to new researchers or
+        students trying to understand computational/data analysis
+        options available to them. It won’t go into anything too deep,
+        but will provide you with a good background for your next
+        steps: you will know what resources are available and know the
+        next steps to use them.
+
+      Day 2-3:
+
+        Scientific Computing Kickstart is a three × half day course
+        for researchers to get started with scientific computing (day
+        1) and high-performance computing (HPC) clusters (day 2). We
+        will take you from being a new user to being competent to run
+        your code at a larger scale than you could before. (However,
+        we don’t cover application-specific matters beyond some
+        Python/R/Matlab basics or focus on the high-performance part:
+        but this is an easy next step after this course).
+
+        This course is good for any researcher who thinks they may
+        need to scale up to larger resources in the next six months,
+        in any field. Even if you don’t use computing clusters, you
+        will be better prepared to understand how computing works on
+        other systems. If you are a student, this is an investment in
+        your skills. By the end of the course you get the hints, ready
+        solutions and copy/paste examples on how to find, run and
+        monitor your applications, and manage your data. In addition
+        to how to optimize your workflow in terms of filesystem
+        traffic, memory usage etc.
+    duration: {hours: 4}
+    begin: 2022-06-07 12:00:00
+  - <<: *kickstart-2022-summer
+    begin: 2022-06-08 12:00:00
+  - <<: *kickstart-2022-summer
+    begin: 2022-06-09 12:00:00
+
+
   - &swd4sc202204
     summary: Software design for scientific computing
     #id: swd4sc202204


### PR DESCRIPTION
- Text could be shortened later, copied from the winter courses.
- Review: check / automerge
